### PR TITLE
Use # instead of = for ps2pdf options in Windows.

### DIFF
--- a/pstool.tex
+++ b/pstool.tex
@@ -98,6 +98,14 @@ v1.3, July 2009:
 \DeclareOptionX{suffix}{\def\pstool@suffix{#1}}
 \ExecuteOptionsX{suffix={-pstool}}
 
+% Under windows, using an '=' character in the options passed to ps2pdf causes problems.
+% It's better to use a '#' character (but that initiates a comment under *nix so there we use '=').
+% -- Heinrich Kruger
+\edef\pstool@eq{\ifwindows\string#\else\string=\fi}
+
+% Remove the quotes around the ps2pdf options (that also seems to cause problems under Windows)
+% -- Heinrich Kruger
+
 % There is an implicit |\space| after the bitmap options.
 \define@choicekey*{pstool.sty}{bitmap}
     [\@tempa\@tempb]{auto,lossless,lossy}{%
@@ -105,17 +113,17 @@ v1.3, July 2009:
     \let\pstool@bitmap@opts\@empty
   \or
     \def\pstool@bitmap@opts{%
-      "-dAutoFilterColorImages=false"
-      "-dAutoFilterGrayImages=false"
-      "-dColorImageFilter=/FlateEncode"
-      "-dGrayImageFilter=/FlateEncode" % space
+      -dAutoFilterColorImages\pstool@eq false
+      -dAutoFilterGrayImages\pstool@eq false
+      -dColorImageFilter\pstool@eq/FlateEncode
+      -dGrayImageFilter\pstool@eq/FlateEncode % space
     }
   \or
     \def\pstool@bitmap@opts{%
-      "-dAutoFilterColorImages=false"
-      "-dAutoFilterGrayImages=false"
-      "-dColorImageFilter=/DCTEncode"
-      "-dGrayImageFilter=/DCTEncode" % space
+      -dAutoFilterColorImages\pstool@eq false
+      -dAutoFilterGrayImages\pstool@eq false
+      -dColorImageFilter\pstool@eq/DCTEncode
+      -dGrayImageFilter\pstool@eq/DCTEncode % space
     }
   \fi
 }
@@ -134,7 +142,7 @@ v1.3, July 2009:
 \ExecuteOptionsX{
   latex-options={},
   dvips-options={},
-  ps2pdf-options={"-dPDFSETTINGS=/prepress"},
+  ps2pdf-options={-dPDFSETTINGS\pstool@eq/prepress},
   pdfcrop-options={}
 }
 


### PR DESCRIPTION
Hi,

I couldn't get pstool to work under windows, because ps2pdf would fail with the error message: "***\* Unable to open the initial device, quitting." Subsequently pdfcrop would also fail because its input file does not exist.

I eventually found this: http://ghostscript.com/doc/7.07/Use.htm#MS_Windows recommending the use of '#' instead of '=' for passing options to ghostscript via ps2pdf. Making this change and removing the quotes around the options for ps2pdf fixed the problem.

While searching for a solution, I found at least two reports of similar problems: http://tex.stackexchange.com/questions/60084/pstool-pdflatex-not-getting-pstool-to-work-latex-error-file-not-found and http://www.mrunix.de/forums/showthread.php?t=73761 (in German). I thought I'd submit the changes I made here, in case it is useful to anyone else.

Regards,
Heinrich Kruger
